### PR TITLE
Added listener to reload collection component after save a new link

### DIFF
--- a/app/Http/Livewire/Links/Collection.php
+++ b/app/Http/Livewire/Links/Collection.php
@@ -11,6 +11,8 @@ class Collection extends Component
 {
     public $user;
 
+    protected $listeners = ['saved' => 'render'];
+
     public function mount()
     {
         $this->user = Auth::user();


### PR DESCRIPTION
According to #12, the table with the list of links must be updated after a new link be saved